### PR TITLE
Adds support to take snapshots from volumes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'barge', git: 'git@github.com:rafaelp/barge.git'
+
 group :development do
   gem 'rubocop', '~> 0.27.0'
   gem 'rubyzip', '~> 1.1.6'
@@ -19,4 +21,5 @@ group :test, :development do
   gem 'webmock', '~> 1.18.0'
   gem 'tins', '~> 1.6.0'
   gem 'coveralls', '~> 0.7.0'
+  gem 'pry', '~> 0.10.4'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 group :test, :development do
   gem 'aruba', '~> 0.8.0'
   gem 'json', '~> 1.8.1'
-  gem 'rake', '>= 0.8.7'
+  gem 'rake', '< 11.0'
   gem 'rspec', '~> 3.3.0'
   gem 'rspec-core', '~> 3.3.0'
   gem 'rspec-expectations', '~> 3.3.0'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DoSnapshot CLI 
+# DoSnapshot CLI
 
 [![Join the chat at https://gitter.im/merqlove/do_snapshot](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/merqlove/do_snapshot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [Project Page at Digital Ocean](https://www.digitalocean.com/community/projects/dosnapshot), comment or vote for this project.
@@ -12,10 +12,11 @@
 
 Use this tool to backup DigitalOcean droplet's via snapshot method, on the fly!
 
-## API Changes: 
-- 03.08.16: DO now automagically keeps our droplets running when snapshot is processing, so:  
-  Added options `--shutdown`, `--no-shutdown`.    
-  `shutdown` now disabled by default, no downtime anymore, `YES`!  
+## API Changes:
+- 03.02.17: Adds support to make snapshots of volumes
+- 03.08.16: DO now automagically keeps our droplets running when snapshot is processing, so:
+  Added options `--shutdown`, `--no-shutdown`.
+  `shutdown` now disabled by default, no downtime anymore, `YES`!
   If you want `shutdown` back use `--shutdown` option.
 - 08.01.16: now we have to use DO API V2 only, because V1 is not work anymore.
 - 17.10.15: now we use DO API V2 by default, due V1 deprecation at 11.2015.
@@ -42,18 +43,34 @@ Ruby versions 1.9.3 and higher. JRuby 1.7, 9.0.0.0 or later is also supported.
 
 ## Installation
 
+### While this fork is not merged into official gem
+
+Install [specific_install](https://github.com/rdp/specific_install) gem
+
+    $ gem install specific_install
+
+Install [this version of barge](https://github.com/rafaelp/barge) (that supports volumes and snapshots)
+
+    $ gem specific_install https://github.com/rafaelp/barge
+
+Install [this version of do_snapshot](https://github.com/rafaelp/do_snapshot/tree/volumes)
+
+    $ gem specific_install https://github.com/rafaelp/do_snapshot volumes
+
+### Instructions to install latest version of official gem
+
 Install it yourself as:
 
     $ gem install do_snapshot
-    
+
 System Wide Install (OSX, *nix):
-  
+
     $ sudo gem install do_snapshot
-        
+
 For **OSX** users ([Homebrew Tap](http://github.com/merqlove/homebrew-do-snapshot)):
 
     $ brew tap merqlove/do-snapshot && brew install do_snapshot
-    
+
     $ do_snapshot -V
 
 Standalone with one-liner:
@@ -61,36 +78,36 @@ Standalone with one-liner:
     $ wget https://assets.merqlove.ru.s3.amazonaws.com/do_snapshot/do_snapshot.tgz && sudo tar -xzf do_snapshot.tgz /usr/local/lib/ && sudo ln -s /usr/local/lib/do_snapshot/bin/do_snapshot /usr/local/bin/do_snapshot
 
 Standalone pack for **Unix/Linux** users: [Download](https://assets.merqlove.ru.s3.amazonaws.com/do_snapshot/do_snapshot.tgz)
- 
+
     $ wget https://assets.merqlove.ru.s3.amazonaws.com/do_snapshot/do_snapshot.tgz # if not done.
-    
+
     # Example Install into /usr/local
-    
-    $ tar -xzf do_snapshot.tgz /usr/local/ && ln -s /usr/local/do_snapshot/bin/do_snapshot /usr/local/bin/do_snapshot 
-    $ do_snapshot help      
+
+    $ tar -xzf do_snapshot.tgz /usr/local/ && ln -s /usr/local/do_snapshot/bin/do_snapshot /usr/local/bin/do_snapshot
+    $ do_snapshot help
 
 Standalone Zip pack for others: [Download](https://assets.merqlove.ru.s3.amazonaws.com/do_snapshot/do_snapshot.zip)
-    
+
 ## Usage
 
 Mainly it's pretty simple:
 
     $ do_snapshot --only 123456 -k 5 -c -v
 
-### Setup 
+### Setup
 
 ### Digitalocean API V2 (default):
 You'll need to generate an access token in Digital Ocean's control panel at https://cloud.digitalocean.com/settings/applications
-    
+
     $ export DIGITAL_OCEAN_ACCESS_TOKEN="SOMETOKEN"
-    
+
 If you want to set keys without environment, than set it via options when you run do_snapshot:
-    
-    $ do_snapshot --digital-ocean-access-token YOURLONGTOKEN   
 
-### How-To 
+    $ do_snapshot --digital-ocean-access-token YOURLONGTOKEN
 
-##### Tutorials: 
+### How-To
+
+##### Tutorials:
 - [Automate Taking Snapshots of Your DigitalOcean Droplets with DOSnapshot
 , Tyler Longren](https://longren.io/automate-making-snapshots-of-your-digitalocean-droplets/)
 - [How to Automate Taking Digital Ocean Droplet Snaphot with DoSnapShot Script, Arun Kumar](http://www.ashout.com/automate-digital-ocean-droplet-snaphot/)
@@ -98,22 +115,22 @@ If you want to set keys without environment, than set it via options when you ru
 Here we `keeping` only 5 **latest** snapshots and cleanup older after new one is created. If creation of snapshots failed no one will be deleted. By default we keeping `10` droplets.
 
     $ do_snapshot --keep 5 -c
-    
+
 Keep latest 3 from selected droplet:
-  
+
     $ do_snapshot --only 123456 --keep 3
-  
+
 Working with all except droplets:
-  
+
     $ do_snapshot --exclude 123456 123457
-  
+
 Keep latest 5 snapshots, send mail notification instead of creating new one:
-  
+
     $ do_snapshot --keep 10 --stop --mail to:yourmail@example.com
-    
+
 <img src="https://raw.githubusercontent.com/merqlove/do_snapshot/master/assets/safe_mode.png" style="max-width:100%" alt="DoSnapshot Safe Mode Example">
-    
-E-mail notifications disabled out of the box. 
+
+E-mail notifications disabled out of the box.
 For working mailer you need to set e-mail settings via run options.
 
     --mail to:mail@somehost.com from:from@host.com --smtp address:smtp.gmail.com port:25 user_name:someuser password:somepassword
@@ -125,7 +142,7 @@ For working mailer you need to set e-mail settings via run options.
 ### Real world example
 
     $ bin/do_snapshot --only 123456 -k 3 -c -m to:TO from:FROM -t address:HOST user_name:LOGIN password:PASSWORD port:2525 -v
-    
+
     Checking DigitalOcean Id's.
     Start performing operations
     Setting DigitalOcean Id's.
@@ -143,12 +160,12 @@ For working mailer you need to set e-mail settings via run options.
     All operations has been finished.
     Sending e-mail notification.
 
-### All options:    
+### All options:
 
-    > $ do_snapshot c  
-    
+    > $ do_snapshot c
+
     aliases: s, snap, create
-    
+
     Options:
       -p, [--protocol=1]                                             # Select api version.
                                                                      # Default: 2
@@ -158,9 +175,9 @@ For working mailer you need to set e-mail settings via run options.
       -k, [--keep=5]                                                 # How much snapshots you want to keep?
                                                                      # Default: 10
       -d, [--delay=5]                                                # Delay between snapshot operation status requests.
-                                                                     # Default: 10                                                                    
+                                                                     # Default: 10
           [--timeout=250]                                            # Timeout in sec's for events like Power Off or Create Snapshot.
-                                                                     # Default: 3600                                                                     
+                                                                     # Default: 3600
       -m, [--mail=to:yourmail@example.com]                           # Receive mail if fail or maximum is reached.
       -t, [--smtp=user_name:yourmail@example.com password:password]  # SMTP options.
       -l, [--log=/Users/someone/.do_snapshot/main.log]               # Log file path. By default logging is disabled.
@@ -171,12 +188,12 @@ For working mailer you need to set e-mail settings via run options.
       -q, [--quiet], [--no-quiet]                                    # Quiet mode. If don't need any messages in console.
           [--digital-ocean-access-token=YOURLONGAPITOKEN]            # DIGITAL_OCEAN_ACCESS_TOKEN. if you can't use environment.
           [--digital-ocean-client-id=YOURLONGAPICLIENTID]            # DIGITAL_OCEAN_CLIENT_ID. if you can't use environment.
-          [--digital-ocean-api-key=YOURLONGAPIKEY]                   # DIGITAL_OCEAN_API_KEY. if you can't use environment.    
-    
+          [--digital-ocean-api-key=YOURLONGAPIKEY]                   # DIGITAL_OCEAN_API_KEY. if you can't use environment.
+
     Description:
       `do_snapshot` able to create and cleanup snapshots on your droplets.
-    
-      You can optionally specify parameters to select or exclude some droplets.   
+
+      You can optionally specify parameters to select or exclude some droplets.
 
 ## You can ask, "Why you made this tool?"
 
@@ -189,7 +206,7 @@ For working mailer you need to set e-mail settings via run options.
 - So this tool can save a lot of time for people.
 
 ## Donating:
-Support this project and others by [merqlove](https://gratipay.com/~merqlove/) via [gratipay](https://gratipay.com/~merqlove/).  
+Support this project and others by [merqlove](https://gratipay.com/~merqlove/) via [gratipay](https://gratipay.com/~merqlove/).
 [![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.3.0/dist/gratipay.png)](https://gratipay.com/merqlove/)
 
 ## Dependencies:
@@ -208,7 +225,7 @@ Support this project and others by [merqlove](https://gratipay.com/~merqlove/) v
 
 ### Testing
 
-    $ rake spec 
+    $ rake spec
 
 Copyright (c) 2015 Alexander Merkulov
 

--- a/do_snapshot.gemspec
+++ b/do_snapshot.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'barge', '~> 0.11'
+#  spec.add_dependency 'barge', '~> 0.11'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'pony', '~> 1.1'
 end

--- a/lib/do_snapshot.rb
+++ b/lib/do_snapshot.rb
@@ -69,7 +69,7 @@ module DoSnapshot
   #
   class SnapshotCreateError < RequestActionError
     def initialize(*args)
-      DoSnapshot.logger.error "Droplet id: #{args[0]} is Failed to Snapshot."
+      DoSnapshot.logger.error "Resource id: #{args[0]} is Failed to Snapshot."
       super
     end
   end
@@ -116,4 +116,35 @@ module DoSnapshot
   # Sometimes it connection problem or DigitalOcean API maintenance.
   #
   class SnapshotCleanupError < RequestError; end
+
+  # When Digital Ocean API say us that not found volume by id.
+  # Or something wrong happened.
+  #
+  class VolumeFindError < RequestError
+    def initialize(*args)
+      DoSnapshot.logger.error "Volume id: #{args[0]} Not Found"
+      super
+    end
+  end
+
+  # When Digital Ocean API cannot retrieve list of volumes.
+  # Sometimes it connection problem or DigitalOcean API maintenance.
+  #
+  class VolumeListError < RequestError
+    def initialize(*args)
+      DoSnapshot.logger.error 'Volume Listing is failed to retrieve'
+      super
+    end
+  end
+
+  # When Digital Ocean API cannot retrieve list of volumes.
+  # Sometimes it connection problem or DigitalOcean API maintenance.
+  #
+  class SnapshotListError < RequestError
+    def initialize(*args)
+      DoSnapshot.logger.error 'Snapshot Listing is failed to retrieve'
+      super
+    end
+  end
+
 end

--- a/lib/do_snapshot/adapter/digitalocean_v2.rb
+++ b/lib/do_snapshot/adapter/digitalocean_v2.rb
@@ -93,7 +93,6 @@ module DoSnapshot
       #
       def cleanup_snapshots(instance, size, resource_type = 'droplet')
         snapshots = snapshot_ids(instance, resource_type)
-        require 'pry'
         (0..size).each do |i|
           # noinspection RubyResolve
           snapshot = snapshots[i]

--- a/lib/do_snapshot/adapter/digitalocean_v2.rb
+++ b/lib/do_snapshot/adapter/digitalocean_v2.rb
@@ -33,7 +33,7 @@ module DoSnapshot
         else
           response = client.snapshot.all(resource_type: resource_type)
           fail SnapshotListError, response.message unless response.respond_to?(:snapshots)
-          response.snapshots.sort_by {|s| Time.parse(s["created_at"]) }.map(&:id)
+          response.snapshots.sort_by {|s| DateTime.strptime(s["created_at"]) }.map(&:id)
         end
       end
 

--- a/lib/do_snapshot/adapter/digitalocean_v2.rb
+++ b/lib/do_snapshot/adapter/digitalocean_v2.rb
@@ -27,8 +27,14 @@ module DoSnapshot
         response.droplets
       end
 
-      def snapshots(instance)
-        instance.snapshot_ids
+      def snapshot_ids(instance, resource_type = 'droplet')
+        if instance.snapshot_ids
+          instance.snapshot_ids
+        else
+          response = client.snapshot.all(resource_type: resource_type)
+          fail SnapshotListError, response.message unless response.respond_to?(:snapshots)
+          response.snapshots.sort_by {|s| Time.parse(s["created_at"]) }.map(&:id)
+        end
       end
 
       # Request Power On for droplet
@@ -60,14 +66,19 @@ module DoSnapshot
 
       # Sending event to create snapshot via DigitalOcean API and wait for success
       #
-      def create_snapshot(id, name)
+      def create_snapshot(id, name, resource_type = nil)
         # noinspection RubyResolve,RubyResolve
-        response = client.droplet.snapshot(id, name: name)
+        case resource_type
+        when 'volume'
+          response = client.volume.create_snapshot(id, name: name)
+          fail DoSnapshot::SnapshotCreateError.new(id), response.message unless response.respond_to?(:snapshot)
+        else
+          response = client.droplet.snapshot(id, name: name)
+          fail DoSnapshot::SnapshotCreateError.new(id), response.message unless response.respond_to?(:action)
 
-        fail DoSnapshot::SnapshotCreateError.new(id), response.message unless response.respond_to?(:action)
-
-        # noinspection RubyResolve
-        wait_event(response.action.id)
+          # noinspection RubyResolve
+          wait_event(response.action.id)
+        end
       end
 
       # Checking if droplet is powered off.
@@ -80,15 +91,18 @@ module DoSnapshot
 
       # Cleanup our snapshots.
       #
-      def cleanup_snapshots(instance, size)
+      def cleanup_snapshots(instance, size, resource_type = 'droplet')
+        snapshots = snapshot_ids(instance, resource_type)
+        require 'pry'
         (0..size).each do |i|
           # noinspection RubyResolve
-          snapshot = instance.snapshot_ids[i]
-          action = client.image.destroy(snapshot)
+          snapshot = snapshots[i]
+
+          action = client.snapshot.destroy(snapshot)
 
           logger.debug action unless action.success?
 
-          after_cleanup(instance.id, instance.name, snapshot, action)
+          after_cleanup(instance.id, instance.name, resource_type, snapshot, action)
         end
       end
 
@@ -106,11 +120,29 @@ module DoSnapshot
         @client = ::Barge::Client.new(access_token: ENV['DIGITAL_OCEAN_ACCESS_TOKEN'], timeout: 15, open_timeout: 15)
       end
 
+      # Get single volume from DigitalOcean
+      #
+      def volume(id)
+        # noinspection RubyResolve
+        response = client.volume.show(id)
+        fail VolumeFindError.new(id), response.message unless response.respond_to?(:volume)
+        response.volume
+      end
+
+      # Get volumes list from DigitalOcean
+      #
+      def volumes
+        # noinspection RubyResolve
+        response = client.volume.all
+        fail VolumeListError, response.message unless response.respond_to?(:volumes)
+        response.volumes
+      end
+
       protected
 
-      def after_cleanup(droplet_id, droplet_name, snapshot, action)
+      def after_cleanup(resource_id, resource_name, resource_type, snapshot, action)
         if !action.success?
-          logger.error "Destroy of snapshot #{snapshot} for droplet id: #{droplet_id} name: #{droplet_name} is failed."
+          logger.error "Destroy of snapshot #{snapshot} for #{resource_type} id: #{resource_id} name: #{resource_name} is failed."
         else
           logger.debug "Snapshot: #{snapshot} delete requested."
         end
@@ -129,5 +161,6 @@ module DoSnapshot
         response.action.status.include?('completed') ? true : false
       end
     end
+
   end
 end

--- a/lib/do_snapshot/cli.rb
+++ b/lib/do_snapshot/cli.rb
@@ -34,9 +34,9 @@ module DoSnapshot
 
     desc 'c / s / snap / create', 'DEFAULT. Create and cleanup snapshot\'s'
     long_desc <<-LONGDESC
-    `do_snapshot` able to create and cleanup snapshots on your droplets.
+    `do_snapshot` able to create and cleanup snapshots on your droplets and volumes.
 
-    You can optionally specify parameters to select or exclude some droplets.
+    You can optionally specify parameters to select or exclude some droplets and/or volumes
 
     ### Examples
 
@@ -48,7 +48,19 @@ module DoSnapshot
 
     $ do_snapshot --digital_ocean_api_token SOMELONGTOKEN
 
-    Keep latest 5 and cleanup older if maximum is reached, verbose:
+    Only take snapshots of droplets (default)
+
+    $ do_snapshot -r droplets
+
+    Only take snapshots of volumes
+
+    $ do_snapshot --resource_types volumes
+
+    Take snapshots of both
+
+    $ do_snapshot -r droplets,volumes
+
+    Keep latest 5 droplets and cleanup older if maximum is reached, verbose:
 
     $ do_snapshot -k 5 -c -v
 
@@ -82,6 +94,12 @@ module DoSnapshot
                   aliases: %w( -p ),
                   banner: '1',
                   desc: 'Select api version.'
+    method_option :resource_types,
+                  type: :string,
+                  default: 'droplets',
+                  aliases: %w( -r ),
+                  banner: 'droplets volumes',
+                  desc: 'Select resource types to take snapshots (DEFAULT: droplets).'
     method_option :shutdown,
                   default: false,
                   type: :boolean,

--- a/lib/do_snapshot/command.rb
+++ b/lib/do_snapshot/command.rb
@@ -72,7 +72,7 @@ module DoSnapshot
       logger.info "Start creating snapshot for #{resource_type_singular} id: #{resource.id} name: #{resource.name}."
 
       today         = DateTime.now
-      name          = "#{resource.name}_#{today.strftime('%Y_%m_%d')}"
+      name          = "#{resource.name}_#{today.strftime('%Y-%m-%d-%H-%M')}"
       # noinspection RubyResolve
       snapshot_size = snapshot_size(resource)
 

--- a/lib/do_snapshot/command.rb
+++ b/lib/do_snapshot/command.rb
@@ -7,9 +7,9 @@ module DoSnapshot
   class Command # rubocop:disable ClassLength
     include DoSnapshot::Helpers
 
-    RESET_OPTIONS = [:droplets, :exclude, :only, :keep, :quiet,
+    RESET_OPTIONS = [:resources, :exclude, :only, :keep, :quiet,
                      :stop, :clean, :timeout, :shutdown, :delay,
-                     :protocol, :threads, :api]
+                     :protocol, :threads, :api, :resource_types, :resource_type]
 
     def initialize(*args)
       load_options(*args)
@@ -17,8 +17,15 @@ module DoSnapshot
 
     def snap
       logger.info 'Start performing operations'
-      work_with_droplets
-      power_on_failed_droplets
+      resource_types.split(",").each do |resource_type|
+        # Check option resource_type
+        raise "Invalid resource_type. Valid values are 'droplets' or 'volumes'." unless ['droplets', 'volumes'].include?(resource_type)
+
+        self.resource_type = resource_type
+        work_with_resources
+        power_on_failed_droplets if droplets?
+        clean_variables
+      end
       logger.info 'All operations has been finished.'
 
       mailer.notify if mailer && notify && !quiet
@@ -46,6 +53,7 @@ module DoSnapshot
     end
 
     def stop_droplet(droplet)
+      return if volumes?
       return true unless shutdown
       logger.debug 'Shutting down droplet.'
       api.stop_droplet(droplet.id) unless droplet.status.include? 'off'
@@ -57,27 +65,27 @@ module DoSnapshot
 
     # Trying to create a snapshot.
     #
-    def create_snapshot(droplet) # rubocop:disable MethodLength,Metrics/AbcSize
-      fail_if_shutdown(droplet)
+    def create_snapshot(resource) # rubocop:disable MethodLength,Metrics/AbcSize
+      self.resource_type ||= 'droplets'
+      fail_if_shutdown(resource) if droplets?
 
-      logger.info "Start creating snapshot for droplet id: #{droplet.id} name: #{droplet.name}."
+      logger.info "Start creating snapshot for #{resource_type_singular} id: #{resource.id} name: #{resource.name}."
 
       today         = DateTime.now
-      name          = "#{droplet.name}_#{today.strftime('%Y_%m_%d')}"
+      name          = "#{resource.name}_#{today.strftime('%Y_%m_%d')}"
       # noinspection RubyResolve
-      snapshot_size = api.snapshots(droplet).size
+      snapshot_size = snapshot_size(resource)
 
       logger.debug 'Wait until snapshot will be created.'
-
-      api.create_snapshot droplet.id, name
+      api.create_snapshot resource.id, name, resource_type_singular
 
       snapshot_size += 1
 
       logger.info "Snapshot name: #{name} created successfully."
-      logger.info "Droplet id: #{droplet.id} name: #{droplet.name} snapshots: #{snapshot_size}."
+      logger.info "#{resource_type_singular.capitalize} id: #{resource.id} name: #{resource.name} snapshots: #{snapshot_size}."
 
       # Cleanup snapshots.
-      cleanup_snapshots droplet, snapshot_size if clean
+      cleanup_snapshots resource, snapshot_size if clean
     rescue => e
       case e.class.to_s
       when 'DoSnapshot::SnapshotCleanupError'
@@ -85,12 +93,12 @@ module DoSnapshot
       when 'DoSnapshot::DropletPowerError'
         return
       else
-        raise SnapshotCreateError.new(droplet.id), e.message, e.backtrace
+        raise SnapshotCreateError.new(resource.id, resource_type_singular), e.message, e.backtrace
       end
     end
 
     def power_on_failed_droplets
-      processed_droplet_ids
+      processed_ids
         .select { |id| api.inactive?(id) }
         .each   { |id| api.power_on(id) }
     end
@@ -101,16 +109,21 @@ module DoSnapshot
       @api ||= DoSnapshot::Adapter.api(protocol, delay: delay, timeout: timeout, stop_by: stop_by)
     end
 
-    # Processed droplets
+    # Processed resources
     #
-    def processed_droplet_ids
-      @droplet_ids ||= %w()
+    def processed_ids
+      @processed_ids ||= %w()
+    end
+
+    def clean_variables
+      @processed_ids = nil
+      @threads = []
     end
 
     protected
 
-    attr_accessor :droplets, :exclude, :only
-    attr_accessor :keep, :quiet, :shutdown, :stop, :stop_by_power, :clean, :timeout, :delay, :protocol
+    attr_accessor :resources, :exclude, :only
+    attr_accessor :keep, :quiet, :shutdown, :stop, :stop_by_power, :clean, :timeout, :delay, :protocol, :resource_types, :resource_type
 
     attr_writer :threads, :api
 
@@ -126,32 +139,32 @@ module DoSnapshot
       stop_by_power ? :power_status : :event_status
     end
 
-    # Working with list of droplets.
+    # Working with list of droplets or volumes.
     #
-    def work_with_droplets
-      load_droplets
-      dispatch_droplets
-      logger.debug 'Working with list of DigitalOcean droplets'
+    def work_with_resources
+      load_resources
+      dispatch_resources
+      logger.debug "Working with list of DigitalOcean #{resource_type}"
       thread_chain
     end
 
-    # Getting droplets list from API.
+    # Getting droplets or volumes list from API.
     # And store into object.
     #
-    def load_droplets
-      logger.debug 'Loading list of DigitalOcean droplets'
-      self.droplets = api.droplets
+    def load_resources
+      logger.debug "Loading list of DigitalOcean #{resource_type}"
+      self.resources = api.send(resource_type)
     end
 
     # Dispatch received droplets, each by each.
     #
-    def dispatch_droplets
-      droplets.each do |droplet|
-        id = droplet.id.to_s
+    def dispatch_resources
+      resources.each do |resource|
+        id = resource.id.to_s
         next if exclude.include? id
         next unless only.empty? || only.include?(id)
 
-        prepare_droplet id, droplet.name
+        prepare_resource id, resource.name
       end
     end
 
@@ -163,30 +176,34 @@ module DoSnapshot
 
     # Run threads
     #
-    def thread_runner(droplet)
+    def thread_runner(resource)
       threads << Thread.new do
-        create_snapshot droplet if stop_droplet(droplet)
+        create_snapshot resource if volumes? or stop_droplet(resource)
       end
     end
 
-    # Preparing droplet to take a snapshot.
+    # Preparing droplet or volume to take a snapshot.
     # Droplet instance must be powered off first!
     #
-    def prepare_droplet(id, name)
-      logger.debug "Droplet id: #{id} name: #{name}\n"
-      droplet = api.droplet id
+    def prepare_resource(id, name)
+      logger.debug "#{resource_type.capitalize} id: #{id} name: #{name}\n"
+      resource = api.send(resource_type_singular, id)
 
-      return unless droplet
-      logger.info "Preparing droplet id: #{droplet.id} name: #{droplet.name} to take snapshot."
-      return if too_much_snapshots?(droplet)
-      processed_droplet_ids << droplet.id
-      thread_runner(droplet)
+      return unless resource
+      logger.info "Preparing #{resource_type_singular} id: #{resource.id} name: #{resource.name} to take snapshot."
+      return if too_much_snapshots?(resource)
+      processed_ids << resource.id
+      thread_runner(resource)
     end
 
     def too_much_snapshots?(instance)
-      return false if api.snapshots(instance).size < keep
+      return false if snapshot_size(instance) < keep
       warning_size(instance.id, instance.name, keep)
       stop ? true : false
+    end
+
+    def snapshot_size(instance)
+      api.snapshot_ids(instance, resource_type_singular).size
     end
 
     def fail_if_shutdown(droplet)
@@ -196,14 +213,14 @@ module DoSnapshot
 
     # Cleanup our snapshots.
     #
-    def cleanup_snapshots(droplet, size) # rubocop:disable Metrics/AbcSize
+    def cleanup_snapshots(resource, size) # rubocop:disable Metrics/AbcSize
       return unless size > keep
 
-      warning_size(droplet.id, droplet.name, size)
+      warning_size(resource.id, resource.name, keep)
 
-      logger.debug "Cleaning up snapshots for droplet id: #{droplet.id} name: #{droplet.name}."
+      logger.debug "Cleaning up snapshots for #{resource_type_singular} id: #{resource.id} name: #{resource.name}."
 
-      api.cleanup_snapshots(droplet, size - keep - 1)
+      api.cleanup_snapshots(resource, size - keep - 1, resource_type_singular)
     rescue => e
       raise SnapshotCleanupError, e.message, e.backtrace
     end
@@ -211,9 +228,26 @@ module DoSnapshot
     # Helpers
     #
     def warning_size(id, name, keep)
-      message = "For droplet with id: #{id} and name: #{name} the maximum number #{keep} of snapshots is reached."
+      message = "For #{resource_type_singular} with id: #{id} and name: #{name} the maximum number #{keep} of snapshots is reached."
       logger.warn message
       @notify = true
+    end
+
+    def droplets?
+      resource_type == 'droplets'
+    end
+
+    def volumes?
+      resource_type == 'volumes'
+    end
+
+    def resource_type_singular
+      case resource_type
+      when 'droplets'
+        'droplet'
+      when 'volumes'
+        'volume'
+      end
     end
   end
 end

--- a/spec/do_snapshot/runner_spec.rb
+++ b/spec/do_snapshot/runner_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe DoSnapshot::Runner, type: :aruba do
 
       it 'shows a help message for specific commands' do
         run 'do_snapshot help snap'
-        expect(all_stdout).to include('`do_snapshot` able to create and cleanup snapshots on your droplets.')
+        expect(all_stdout).to include('`do_snapshot` able to create and cleanup snapshots on your droplets and volumes.')
       end
 
       it 'sure no warning about credentials' do

--- a/spec/do_snapshot_spec.rb
+++ b/spec/do_snapshot_spec.rb
@@ -69,7 +69,38 @@ RSpec.describe DoSnapshot do
     it 'should work' do
       error.new(droplet_id)
       expect(DoSnapshot.logger.buffer)
-        .to include "Droplet id: #{droplet_id} is Failed to Snapshot."
+        .to include "Resource id: #{droplet_id} is Failed to Snapshot."
     end
   end
+
+  describe DoSnapshot::VolumeFindError do
+    subject(:error) { described_class }
+
+    it 'should work' do
+      error.new(droplet_id)
+      expect(DoSnapshot.logger.buffer)
+        .to include "Volume id: #{droplet_id} Not Found"
+    end
+  end
+
+  describe DoSnapshot::VolumeListError do
+    subject(:error) { described_class }
+
+    it 'should work' do
+      error.new
+      expect(DoSnapshot.logger.buffer)
+        .to include 'Volume Listing is failed to retrieve'
+    end
+  end
+
+  describe DoSnapshot::SnapshotListError do
+    subject(:error) { described_class }
+
+    it 'should work' do
+      error.new
+      expect(DoSnapshot.logger.buffer)
+        .to include 'Snapshot Listing is failed to retrieve'
+    end
+  end
+
 end

--- a/spec/fixtures/digitalocean/v2/response_snapshot.json
+++ b/spec/fixtures/digitalocean/v2/response_snapshot.json
@@ -1,0 +1,12 @@
+{
+  "snapshot": {
+    "id": "50cacc62-f214-11e6-a9ab-000f53315820",
+    "name": "volume-nyc1-01_2017_02_13_670399885933",
+    "regions": ["nyc1"],
+    "created_at": "2017-02-13T17:46:15Z",
+    "resource_id": "cff9806c-f1f4-11e6-97e1-000f53315a41",
+    "resource_type": "volume",
+    "min_disk_size": 1,
+    "size_gigabytes": 0
+  }
+}

--- a/spec/fixtures/digitalocean/v2/show_snapshot.json
+++ b/spec/fixtures/digitalocean/v2/show_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "snapshot": {
+    "id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "name": "Ubuntu Foo",
+    "regions": [
+      "nyc1"
+    ],
+    "created_at": "2014-07-29T14:35:40Z",
+    "resource_type": "volume",
+    "resource_id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "min_disk_size": 10,
+    "size_gigabytes": 0.4
+  }
+}

--- a/spec/fixtures/digitalocean/v2/show_snapshots.json
+++ b/spec/fixtures/digitalocean/v2/show_snapshots.json
@@ -1,0 +1,43 @@
+{
+  "snapshots": [
+    {
+      "id": "5019770",
+      "name": "Ubuntu 13.04",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "droplet",
+      "resource_id": "100823",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    },
+    {
+      "id": "5019903",
+      "name": "Ubuntu Foo",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "droplet",
+      "resource_id": "100823",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    },
+    {
+      "id": "119192817",
+      "name": "Ubuntu Foo",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "volume",
+      "resource_id": "7724db7c-e098-11e5-b522-000f53304e51",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    }
+  ],
+  "meta": {
+    "total": 3
+  }
+}

--- a/spec/fixtures/digitalocean/v2/show_snapshots_empty.json
+++ b/spec/fixtures/digitalocean/v2/show_snapshots_empty.json
@@ -1,0 +1,5 @@
+{
+  "snapshots": [],
+  "links": {},
+  "meta": {"total": 0}
+}

--- a/spec/fixtures/digitalocean/v2/show_volume.json
+++ b/spec/fixtures/digitalocean/v2/show_volume.json
@@ -1,0 +1,34 @@
+{
+  "volume": {
+    "id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "region": {
+      "name": "New York 1",
+      "slug": "nyc1",
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "available": true
+    },
+    "droplet_ids": [
+
+    ],
+    "name": "Example",
+    "description": "Block store for examples",
+    "size_gigabytes": 10,
+    "created_at": "2016-03-02T17:00:49Z"
+  }
+}

--- a/spec/fixtures/digitalocean/v2/show_volumes.json
+++ b/spec/fixtures/digitalocean/v2/show_volumes.json
@@ -1,0 +1,41 @@
+{
+  "volumes": [
+    {
+      "id": "7724db7c-e098-11e5-b522-000f53304e51",
+      "region": {
+        "name": "New York 1",
+        "slug": "nyc1",
+        "sizes": [
+          "512mb",
+          "1gb",
+          "2gb",
+          "4gb",
+          "8gb",
+          "16gb",
+          "32gb",
+          "48gb",
+          "64gb"
+        ],
+        "features": [
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata"
+        ],
+        "available": true
+      },
+      "droplet_ids": [
+
+      ],
+      "name": "Example",
+      "description": "Block store for examples",
+      "size_gigabytes": 10,
+      "created_at": "2016-03-02T17:00:49Z"
+    }
+  ],
+  "links": {
+  },
+  "meta": {
+    "total": 1
+  }
+}

--- a/spec/fixtures/digitalocean/v2/show_volumes_empty.json
+++ b/spec/fixtures/digitalocean/v2/show_volumes_empty.json
@@ -1,0 +1,5 @@
+{
+  "volumes": [],
+  "links": {},
+  "meta": {"total": 0}
+}

--- a/spec/shared/api_v2_helpers.rb
+++ b/spec/shared/api_v2_helpers.rb
@@ -2,20 +2,29 @@
 require 'spec_helper'
 
 RSpec.shared_context 'api_v2_helpers' do
-  let(:api_base)           { 'https://api.digitalocean.com/v2' }
-  let(:droplets_api_base)  { "#{api_base}/droplets" }
-  let(:api_access_token)   { "Bearer #{access_token}" }
-  let(:events_api_base)    { "#{api_base}/droplets/[droplet_id]/actions" }
-  let(:actions_api_base)   { "#{api_base}/actions" }
-  let(:images_api_base)    { "#{api_base}/images" }
-  let(:image_destroy_uri)  { "#{images_api_base}/[id]" }
-  let(:droplets_uri)       { "#{droplets_api_base}?per_page=200" }
-  let(:droplet_find_uri)   { "#{droplets_api_base}/[id]?per_page=200" }
-  let(:droplet_stop_uri)   { "#{droplets_api_base}/[id]/actions" }
-  let(:droplet_start_uri)  { "#{droplets_api_base}/[id]/actions" }
-  let(:snapshot_uri)       { "#{droplets_api_base}/[id]/actions" }
-  let(:event_find_uri)     { "#{events_api_base}/[id]" }
-  let(:action_find_uri)    { "#{actions_api_base}/[id]?per_page=200" }
+  let(:api_base)             { 'https://api.digitalocean.com/v2' }
+  let(:droplets_api_base)    { "#{api_base}/droplets" }
+  let(:api_access_token)     { "Bearer #{access_token}" }
+  let(:events_api_base)      { "#{api_base}/droplets/[droplet_id]/actions" }
+  let(:actions_api_base)     { "#{api_base}/actions" }
+  let(:images_api_base)      { "#{api_base}/images" }
+  let(:image_destroy_uri)    { "#{images_api_base}/[id]" }
+  let(:droplets_uri)         { "#{droplets_api_base}?per_page=200" }
+  let(:droplet_find_uri)     { "#{droplets_api_base}/[id]?per_page=200" }
+  let(:droplet_stop_uri)     { "#{droplets_api_base}/[id]/actions" }
+  let(:droplet_start_uri)    { "#{droplets_api_base}/[id]/actions" }
+  let(:droplet_snapshot_uri) { "#{droplets_api_base}/[id]/actions" }
+  let(:event_find_uri)       { "#{events_api_base}/[id]" }
+  let(:action_find_uri)      { "#{actions_api_base}/[id]?per_page=200" }
+  let(:volumes_api_base)     { "#{api_base}/volumes" }
+  let(:volumes_uri)          { "#{volumes_api_base}?per_page=200" }
+  let(:volume_find_uri)      { "#{volumes_api_base}/[id]?per_page=200" }
+  let(:volume_snapshot_uri)  { "#{volumes_api_base}/[id]/snapshots" }
+  let(:snapshots_api_base)   { "#{api_base}/snapshots" }
+  let(:snapshot_destroy_uri) { "#{snapshots_api_base}/[id]" }
+  def snapshots_uri(resource_type)
+    "#{api_base}/snapshots?per_page=200&resource_type=#{resource_type}"
+  end
 
   # List of droplets
   #
@@ -80,17 +89,17 @@ RSpec.shared_context 'api_v2_helpers' do
                 )
   end
 
-  # Snapshot
+  # Droplet Snapshot
   #
   def stub_droplet_snapshot(id, name)
-    stub_with_id_name(snapshot_uri, id, name, 'v2/response_event', :post,
+    stub_with_id_name(droplet_snapshot_uri, id, name, 'v2/response_event', :post,
                       type: 'snapshot',
                       name: name
                      )
   end
 
   def stub_droplet_snapshot_fail(id, name)
-    stub_with_id_name(snapshot_uri, id, name, 'v2/error_message', :post,
+    stub_with_id_name(droplet_snapshot_uri, id, name, 'v2/error_message', :post,
                       {
                         type: 'snapshot',
                         name: name
@@ -121,6 +130,86 @@ RSpec.shared_context 'api_v2_helpers' do
 
   def stub_image_destroy_fail(id)
     stub_with_id(image_destroy_uri, id, 'v2/error_message', :delete, nil, 404)
+  end
+
+  # List of volumes
+  #
+  def stub_volumes
+    stub_without_id(volumes_uri, 'v2/show_volumes')
+  end
+
+  def stub_volumes_empty
+    stub_without_id(volumes_uri, 'v2/show_volumes_empty')
+  end
+
+  def stub_volumes_fail
+    stub_without_id(volumes_uri, 'v2/error_message')
+  end
+
+  # Volume data
+  #
+  def stub_volume(id)
+    stub_with_id(volume_find_uri, id, 'v2/show_volume')
+  end
+
+  def stub_volume_fail(id)
+    stub_with_id(volume_find_uri, id, 'v2/error_message')
+  end
+
+  # Volume Snapshot
+  #
+  def stub_volume_snapshots(id)
+    stub_with_id(volume_snapshot_uri, id, 'v2/response_snapshot')
+  end
+
+  def stub_volume_snapshot(id, name)
+    stub_with_id_name(volume_snapshot_uri, id, name, 'v2/response_snapshot', :post,
+                      name: name
+                     )
+  end
+
+  def stub_volume_snapshot_fail(id, name)
+    stub_with_id_name(volume_snapshot_uri, id, name, 'v2/error_message', :post,
+                      {
+                        name: name
+                      },
+                      404
+                     )
+  end
+
+
+  # List of snapshots
+  #
+  def stub_snapshots(resource_type)
+    stub_without_id(snapshots_uri(resource_type), 'v2/show_snapshots')
+  end
+
+  def stub_snapshots_empty(resource_type)
+    stub_without_id(snapshots_uri(resource_type), 'v2/show_snapshots_empty')
+  end
+
+  def stub_snapshots_fail(resource_type)
+    stub_without_id(snapshots_uri(resource_type), 'v2/error_message')
+  end
+
+  # Snapshot data
+  #
+  def stub_snapshot(id)
+    stub_with_id(snapshot_find_uri, id, 'v2/show_snapshot')
+  end
+
+  def stub_snapshot_fail(id)
+    stub_with_id(snapshot_find_uri, id, 'v2/error_message')
+  end
+
+  # Snapshot actions
+  #
+  def stub_snapshot_destroy(id)
+    stub_with_id(snapshot_destroy_uri, id, 'v2/empty', :delete, nil, 204)
+  end
+
+  def stub_snapshot_destroy_fail(id)
+    stub_with_id(snapshot_destroy_uri, id, 'v2/error_message', :delete, nil, 404)
   end
 
   # Stub helpers

--- a/spec/shared/environment.rb
+++ b/spec/shared/environment.rb
@@ -8,36 +8,41 @@ RSpec.shared_context 'environment' do
     allow(Pony).to receive(:deliver) { |mail| mail }
   end
 
-  let(:client_key)          { 'foo' }
-  let(:api_key)             { 'bar' }
-  let(:access_token)        { 'sometoken' }
-  let(:event_id)            { '7499' }
-  let(:droplet_id)          { '100823' }
-  let(:image_id)            { '5019770' }
-  let(:image_id2)           { '5019903' }
-  let(:cli_env_nil)         { Hash['DIGITAL_OCEAN_CLIENT_ID' => nil, 'DIGITAL_OCEAN_API_KEY' => nil, 'DIGITAL_OCEAN_ACCESS_TOKEN' => nil] }
-  let(:cli_keys)            { Thor::CoreExt::HashWithIndifferentAccess.new(digital_ocean_access_token: access_token) }
-  let(:cli_keys_other)      { Thor::CoreExt::HashWithIndifferentAccess.new(digital_ocean_access_token: 'NOTTOK') }
-  let(:snapshot_name)       { "example.com_#{DateTime.now.strftime('%Y_%m_%d')}" }
-  let(:default_options)     { Hash[protocol: 2, only: %w( 100823 ), exclude: %w(), keep: 3, stop: false, trace: true, clean: true, delay: 0, shutdown: true, timeout: 600] }
-  let(:default_options_cli) { default_options.reject { |key, _| %w( droplets threads ).include?(key.to_s) } }
-  let(:no_exclude)          { [] }
-  let(:exclude)             { %w( 100824 100825 ) }
-  let(:no_only)             { [] }
-  let(:only)                { %w( 100823 100824 ) }
-  let(:stop)                { true }
-  let(:no_stop)             { false }
-  let(:quiet)               { true }
-  let(:no_quiet)            { false }
-  let(:clean)               { true }
-  let(:no_clean)            { false }
-  let(:shutdown)            { true }
-  let(:timeout)             { 600 }
-  let(:delay)               { 0 }
-  let(:log_path)            { "#{project_path}/log/test.log" }
-  let(:mail_options)        { Thor::CoreExt::HashWithIndifferentAccess.new(to: 'mail@somehost.com', from: 'from@host.com') }
-  let(:smtp_options)        { Thor::CoreExt::HashWithIndifferentAccess.new(address: 'smtp.gmail.com', port: '25', user_name: 'someuser', password: 'somepassword') }
-  let(:log)                 { Thor::CoreExt::HashWithIndifferentAccess.new(log: log_path) }
+  let(:client_key)           { 'foo' }
+  let(:api_key)              { 'bar' }
+  let(:access_token)         { 'sometoken' }
+  let(:event_id)             { '7499' }
+  let(:droplet_id)           { '100823' }
+  let(:volume_id)            { '7724db7c-e098-11e5-b522-000f53304e51' }
+  let(:image_id)             { '5019770' }
+  let(:image_id2)            { '5019903' }
+  let(:snapshot_id)          { '5019770' }
+  let(:snapshot_id2)         { '5019903' }
+  let(:snapshot_id3)         { '119192817' }
+  let(:cli_env_nil)          { Hash['DIGITAL_OCEAN_CLIENT_ID' => nil, 'DIGITAL_OCEAN_API_KEY' => nil, 'DIGITAL_OCEAN_ACCESS_TOKEN' => nil] }
+  let(:cli_keys)             { Thor::CoreExt::HashWithIndifferentAccess.new(digital_ocean_access_token: access_token) }
+  let(:cli_keys_other)       { Thor::CoreExt::HashWithIndifferentAccess.new(digital_ocean_access_token: 'NOTTOK') }
+  let(:snapshot_name)        { "example.com_#{DateTime.now.strftime('%Y_%m_%d')}" }
+  let(:volume_snapshot_name) { "Example_#{DateTime.now.strftime('%Y_%m_%d')}" }
+  let(:default_options)      { Hash[protocol: 2, resource_types: 'droplets', only: %w( 100823 ), exclude: %w(), keep: 3, stop: false, trace: true, clean: true, delay: 0, shutdown: true, timeout: 600] }
+  let(:default_options_cli)  { default_options.reject { |key, _| %w( droplets threads ).include?(key.to_s) } }
+  let(:no_exclude)           { [] }
+  let(:exclude)              { %w( 100824 100825 ) }
+  let(:no_only)              { [] }
+  let(:only)                 { %w( 100823 100824 ) }
+  let(:stop)                 { true }
+  let(:no_stop)              { false }
+  let(:quiet)                { true }
+  let(:no_quiet)             { false }
+  let(:clean)                { true }
+  let(:no_clean)             { false }
+  let(:shutdown)             { true }
+  let(:timeout)              { 600 }
+  let(:delay)                { 0 }
+  let(:log_path)             { "#{project_path}/log/test.log" }
+  let(:mail_options)         { Thor::CoreExt::HashWithIndifferentAccess.new(to: 'mail@somehost.com', from: 'from@host.com') }
+  let(:smtp_options)         { Thor::CoreExt::HashWithIndifferentAccess.new(address: 'smtp.gmail.com', port: '25', user_name: 'someuser', password: 'somepassword') }
+  let(:log)                  { Thor::CoreExt::HashWithIndifferentAccess.new(log: log_path) }
 
   def stub_all_api(droplets = nil, active = false)
     drops = []
@@ -47,6 +52,13 @@ RSpec.shared_context 'environment' do
         stub_droplet: (active ? stub_droplet(droplet) : stub_droplet_inactive(droplet))
       ].merge(stub_droplet_api(droplet))
     end
+    volumes ||= [volume_id]
+    volumes.each do |volume|
+      drops.push Hash[
+        stub_volume: stub_volume(volume)
+      ].merge(stub_volume_api(volume))
+    end
+
     stubs = Hash[drops: drops]
     @stubs = stubs.merge(default_stub_api)
   end
@@ -59,12 +71,22 @@ RSpec.shared_context 'environment' do
     }
   end
 
+  def stub_volume_api(volume)
+    {
+      stub_volume_find_snapshots: stub_snapshots('volume'),
+      stub_volume_snapshots: stub_volume_snapshots(volume),
+      stub_volume_snapshot: stub_volume_snapshot(volume, volume_snapshot_name)
+    }
+  end
+
   def default_stub_api
     {
       stub_event_done: stub_event_done(event_id),
       stub_droplets: stub_droplets,
-      stub_image_destroy1: stub_image_destroy(image_id),
-      stub_image_destroy2: stub_image_destroy(image_id2)
+      stub_volumes: stub_volumes,
+      stub_snapshot_destroy1: stub_snapshot_destroy(snapshot_id),
+      stub_snapshot_destroy2: stub_snapshot_destroy(snapshot_id2),
+      stub_snapshot_destroy3: stub_snapshot_destroy(snapshot_id3)
     }
   end
 

--- a/spec/shared/environment.rb
+++ b/spec/shared/environment.rb
@@ -22,8 +22,8 @@ RSpec.shared_context 'environment' do
   let(:cli_env_nil)          { Hash['DIGITAL_OCEAN_CLIENT_ID' => nil, 'DIGITAL_OCEAN_API_KEY' => nil, 'DIGITAL_OCEAN_ACCESS_TOKEN' => nil] }
   let(:cli_keys)             { Thor::CoreExt::HashWithIndifferentAccess.new(digital_ocean_access_token: access_token) }
   let(:cli_keys_other)       { Thor::CoreExt::HashWithIndifferentAccess.new(digital_ocean_access_token: 'NOTTOK') }
-  let(:snapshot_name)        { "example.com_#{DateTime.now.strftime('%Y_%m_%d')}" }
-  let(:volume_snapshot_name) { "Example_#{DateTime.now.strftime('%Y_%m_%d')}" }
+  let(:snapshot_name)        { "example.com_#{DateTime.now.strftime('%Y-%m-%d-%H-%M')}" }
+  let(:volume_snapshot_name) { "Example_#{DateTime.now.strftime('%Y-%m-%d-%H-%M')}" }
   let(:default_options)      { Hash[protocol: 2, resource_types: 'droplets', only: %w( 100823 ), exclude: %w(), keep: 3, stop: false, trace: true, clean: true, delay: 0, shutdown: true, timeout: 600] }
   let(:default_options_cli)  { default_options.reject { |key, _| %w( droplets threads ).include?(key.to_s) } }
   let(:no_exclude)           { [] }

--- a/spec/shared/uri_helpers.rb
+++ b/spec/shared/uri_helpers.rb
@@ -9,5 +9,10 @@ RSpec.shared_context 'uri_helpers' do
   let(:image_destroy_url) { url_with_id(image_destroy_uri, image_id) }
   let(:image_destroy2_url) { url_with_id(image_destroy_uri, image_id2) }
   let(:action_find_url) { url_with_id(action_find_uri, event_id) }
-  let(:droplet_snapshot_url) { url_with_id_name(snapshot_uri, droplet_id, snapshot_name) }
+  let(:droplet_snapshot_url) { url_with_id_name(droplet_snapshot_uri, droplet_id, snapshot_name) }
+  let(:volume_url) { url_with_id(volume_find_uri, volume_id) }
+  let(:volume_snapshot_url) { url_with_id_name(volume_snapshot_uri, volume_id, snapshot_name) }
+  let(:snapshot_destroy_url) { url_with_id(snapshot_destroy_uri, snapshot_id) }
+  let(:snapshot_destroy2_url) { url_with_id(snapshot_destroy_uri, snapshot_id2) }
+  let(:snapshot_destroy3_url) { url_with_id(snapshot_destroy_uri, snapshot_id3) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ Bundler.setup
 require 'do_snapshot/cli'
 require 'webmock/rspec'
 require 'fileutils'
+require 'pry'
 require_relative 'shared/api_helpers'
 require_relative 'shared/api_v2_helpers'
 require_relative 'shared/uri_helpers'


### PR DESCRIPTION
I've implemented support to take snapshots of volumes. I had to update barge gem also.
In the README I put the instructions to install the specific version of barge.

Here are some examples of the new parameter.

Only take snapshots of droplets (default)

  $ do_snapshot -r droplets

  Only take snapshots of volumes

  $ do_snapshot --resource_types volumes

  Take snapshots of both

  $ do_snapshot -r droplets,volumes

All other parameters (--only, --exclude, --clean, etc) works for volumes as well.